### PR TITLE
Bugfix, will now return false when given float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Dependency directories
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - 'iojs'
+  - '8'
+  - '7'
+  - '6'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ is-int [![Build Status](https://travis-ci.org/RivalNick/is-int.svg?branch=master
 > Check if a variable is an integer.
 
 ## Install
-```shell
+```bash
 npm install is-int
 ```
 
@@ -12,9 +12,19 @@ npm install is-int
 ```javascript
 var isInt = require('is-int');
 
-isInt(400);	// => true
+isInt(1);	// => true
 
-isInt("hello");	// => true
+isInt(1.1);	// => false
+
+isInt('1');	// => false
+
+isInt('foo');	// => false
+```
+
+## Test
+```bash
+npm install
+npm test
 ```
 
 ## Author

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
 module.exports = function (x) {
-	var type = typeof x;
-
-	return type !== null && (type === 'number');
-}
+    return parseInt(x) === x;
+};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "is-int",
-  "version": "1.0.0",
-  "description": "Check if a value is an number",
+  "version": "2.0.0",
+  "description": "Check if a value is an integer",
   "main": "index.js",
   "scripts": {
-    "test": "node test.js"
+    "test": "mocha test.js"
   },
   "repository": {
     "type": "git",
@@ -16,12 +16,20 @@
     "evaluate"
   ],
   "author": "Nicky Laczko",
+  "contributors": [
+    {
+      "name": "Anders Åkerö",
+      "email": "anders@akero.eu",
+      "url": "https://github.com/anders-akero"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rivalnick/is-int/issues"
   },
-  "dependencies": {
-    "kheck": "^1.0.0"
+  "devDependencies": {
+    "chai": "^4.1.0",
+    "mocha": "^3.4.2"
   },
   "homepage": "https://github.com/rivalnick/is-int#readme"
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,38 @@
 'use strict';
 
-var fn = require('./');
-var kheck = require('kheck');
+var expect = require('chai').expect;
 
-if (fn(500)) {
-	kheck.Pass("Passed!");
-} else {
-	kheck.Fail("Fail!");
-}
+var isInt = require('./index');
+
+describe('is-int', function () {
+    describe('integer', function () {
+        it('should return true', function () {
+            expect(isInt(1)).to.be.true;
+        });
+    });
+    describe('float', function () {
+        it('should return false', function () {
+            expect(isInt(1.1)).to.be.false;
+        });
+    });
+    describe('string', function () {
+        it('should return false', function () {
+            expect(isInt('foo')).to.be.false;
+        });
+    });
+    describe('number as string', function () {
+        it('should return false', function () {
+            expect(isInt('1')).to.be.false;
+        });
+    });
+    describe('array', function () {
+        it('should return false', function () {
+            expect(isInt([1, 2, 3])).to.be.false;
+        });
+    });
+    describe('object', function () {
+        it('should return false', function () {
+            expect(isInt({foo: 'bar'})).to.be.false;
+        });
+    });
+});


### PR DESCRIPTION
Bugfix for [issue with float](https://github.com/AsyncNick/is-int/issues/2)
`npm test` gives the following result:
```
  is-int
    integer
      ✓ should return true
    float
      ✓ should return false
    string
      ✓ should return false
    number as string
      ✓ should return false
    array
      ✓ should return false
    object
      ✓ should return false

  6 passing (10ms)
```